### PR TITLE
Fixed family for sockaddr for mac

### DIFF
--- a/include/sockpp/sock_address.h
+++ b/include/sockpp/sock_address.h
@@ -88,8 +88,12 @@ public:
 	 *  	   address is not know, returns AF_UNSPEC.
 	 */
 	virtual sa_family_t family() const {
-		return (size() < sizeof(sa_family_t))
+#ifdef __APPLE__
+        return sockaddr_ptr()->sa_family;
+#else
+        return (size() < sizeof(sa_family_t))
 			? AF_UNSPEC : *reinterpret_cast<const sa_family_t*>(sockaddr_ptr());
+#endif
 	}
 };
 

--- a/src/connector.cpp
+++ b/src/connector.cpp
@@ -47,7 +47,11 @@ bool connector::connect(const sockaddr* addr, socklen_t len)
 		return false;
 	}
 
-	sa_family_t domain = *(reinterpret_cast<const sa_family_t*>(addr));
+#ifdef __APPLE__
+    sa_family_t domain = addr->sa_family;
+#else
+    sa_family_t domain = *(reinterpret_cast<const sa_family_t*>(addr));
+#endif
 	socket_t h = create(domain);
 
 	if (h == INVALID_SOCKET) {


### PR DESCRIPTION
Signature of mac's kernel `sockaddr` is different:

```
struct sockaddr {
	__uint8_t	sa_len;		/* total length */
	sa_family_t	sa_family;	/* [XSI] address family */
	char		sa_data[14];	/* [XSI] addr value (actually larger) */
};
```

instead of 

```
struct sockaddr{
    sa_family_t   sa_family       address family
    char          sa_data[]       socket address (variable-length data)
};
```

like the code assumes.