### PR TITLE
Fixed problems with sys_error exception

### DIFF
--- a/include/sockpp/exception.h
+++ b/include/sockpp/exception.h
@@ -59,7 +59,7 @@ namespace sockpp {
  * codes are platform 'errno' values (or similar), and the messages are
  * typically derived from the system.
  */
-class sys_error : std::runtime_error
+class sys_error : public std::runtime_error
 {
 	/** The system error number (errno) */
 	int errno_;
@@ -79,6 +79,37 @@ public:
 	 * @return The system error number.
 	 */
 	int error() const { return errno_; }
+};
+
+/**
+ * Errors from getaddrinfo.
+ * These are errors relating to DNS lookup, returned from the getaddrinfo system call.
+ * Their codes are declared in <netdb.h>.
+ */
+class getaddrinfo_error : public std::runtime_error
+{
+	/** The error number, as returned by getaddrinfo. */
+	int error_;
+    /** The hostname being resolved. */
+    std::string hostname_;
+
+public:
+	/**
+	 * Constructs an error with the specified getaddrinfo error code.
+	 * @param err The error number, as returned by getaddrinfo.
+     * @param hostname The DNS name being resolved that triggered the error.
+	 */
+	getaddrinfo_error(int err, const std::string &hostname);
+	/**
+	 * Get the error number.
+	 * @return The error number returned by getaddrinfo.
+	 */
+	int error() const { return error_; }
+    /**
+     * Get the hostname that triggered the error.
+     * @return The hostname that getaddrinfo failed to resolve.
+     */
+    const std::string &hostname() const { return hostname_; }
 };
 
 /////////////////////////////////////////////////////////////////////////////

--- a/include/sockpp/inet_address.h
+++ b/include/sockpp/inet_address.h
@@ -140,6 +140,7 @@ public:
 	 * Attempts to resolve the host name into a 32-bit internet address.
 	 * @param saddr The string host name.
 	 * @return The internet address in network byte order.
+     * @throw sys_error, getaddrinfo_error
 	 */
 	static in_addr_t resolve_name(const std::string& saddr);
 	/**
@@ -154,6 +155,7 @@ public:
 	 * number.
 	 * @param saddr The string host name.
 	 * @param port The port number in native/host byte order.
+     * @throw sys_error, getaddrinfo_error
 	 */
 	void create(const std::string& saddr, in_port_t port);
 	/**

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -38,6 +38,7 @@
 #include "sockpp/exception.h"
 #include <errno.h>
 #include <cstring>
+#include <netdb.h>
 
 using namespace std;
 
@@ -52,6 +53,12 @@ sys_error::sys_error() : sys_error(errno)
 // TODO: Replace strerror() with a thread-safe call.
 
 sys_error::sys_error(int err) : runtime_error(strerror(err)), errno_(err)
+{
+}
+
+
+getaddrinfo_error::getaddrinfo_error(int err, const string &hostname)
+: runtime_error(gai_strerror(err)), error_(err), hostname_(hostname)
 {
 }
 

--- a/src/inet_address.cpp
+++ b/src/inet_address.cpp
@@ -63,11 +63,16 @@ in_addr_t inet_address::resolve_name(const std::string& saddr)
     hints.ai_family = ADDRESS_FAMILY;
     hints.ai_socktype = SOCK_STREAM;
 
-    if (::getaddrinfo(saddr.c_str(), NULL, &hints, &res) != 0)
+    int gai_err = ::getaddrinfo(saddr.c_str(), NULL, &hints, &res);
+    if (gai_err == EAI_SYSTEM)
         throw sys_error();
+    else if (gai_err != 0)
+        throw getaddrinfo_error(gai_err, saddr);
 
     auto ipv4 = reinterpret_cast<sockaddr_in*>(res->ai_addr);
-    return ipv4->sin_addr.s_addr;
+    auto result = ipv4->sin_addr.s_addr;
+    freeaddrinfo(res);
+    return result;
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
* sys_error couldn't be caught as a std::exception because it didn't publicly inherit from it.
* inet_address should not throw a sys_error when getaddrinfo() fails, because getaddrinfo doesn't set errno and doesn't use the same error numbers as errno. Created a new exception class for it.
* Fixed a memory leak in inet_address::resolve_name.

Fixes #18, fixes #19