### PR TITLE
socket::close() preserves last_error()

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -79,13 +79,11 @@ int socket::get_last_error()
 
 bool socket::close(socket_t h)
 {
-	return check_ret_bool(
-		#if defined(_WIN32)
-			::closesocket(h);
-		#else
-			::close(h)
-		#endif
-	);
+    #if defined(_WIN32)
+        return ::closesocket(h) >= 0;
+    #else
+        return ::close(h) >= 0;
+    #endif
 }
 
 // --------------------------------------------------------------------------
@@ -256,7 +254,7 @@ bool socket::shutdown(int how /*=SHUT_RDWR*/)
 }
 
 // --------------------------------------------------------------------------
-// Closes the socket
+// Closes the socket and updates lastErr_
 
 bool socket::close()
 {
@@ -264,7 +262,12 @@ bool socket::close()
 		return true;
 
 	socket_t h = release();
-	return close(h);
+    if (close(h))
+        return true;
+
+    if (lastErr_ == 0)          // Preserve any pre-existing error
+        set_last_error();
+    return false;
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
As a result of fixing #23 in ddf71320, socket::close() now clears the
last_error property to 0. This means when connector::connect() or
acceptor::open() close themselves after encountering an error, the
error code is lost.
Fixed this by changing socket::close to preserve a pre-existing non-
zero last_error.

Fixes #27