### PR TITLE
Made to_timeval work with any timescale

### DIFF
--- a/include/sockpp/socket.h
+++ b/include/sockpp/socket.h
@@ -63,7 +63,16 @@ namespace sockpp {
 #endif
 
 #if !defined(_WIN32)
-	timeval to_timeval(const std::chrono::microseconds& dur);
+    template <class DURATION>
+    timeval to_timeval(DURATION dur)
+    {
+        const std::chrono::seconds sec = std::chrono::duration_cast<std::chrono::seconds>(dur);
+
+        timeval tv;
+        tv.tv_sec  = sec.count();
+        tv.tv_usec = int(std::chrono::duration_cast<std::chrono::microseconds>(dur - sec).count());
+        return tv;
+    }
 #endif
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -47,21 +47,6 @@ using namespace std::chrono;
 namespace sockpp {
 
 /////////////////////////////////////////////////////////////////////////////
-// Some platform-specific functions
-
-#if !defined(_WIN32)
-timeval to_timeval(const microseconds& dur)
-{
-	const seconds sec = duration_cast<seconds>(dur);
-
-	timeval tv;
-    tv.tv_sec  = sec.count();
-    tv.tv_usec = duration_cast<microseconds>(dur - sec).count();
-	return tv;
-}
-#endif
-
-/////////////////////////////////////////////////////////////////////////////
 //								socket
 /////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
I have some code that needs to convert steady_clock durations to
timeval, and that timescale is different from microseconds. So I
trivially changed to_timeval() into a template.