### PR TITLE
Include <netinet/in.h> on FreeBSD

### DIFF
--- a/include/sockpp/platform.h
+++ b/include/sockpp/platform.h
@@ -98,6 +98,9 @@
 	#include <unistd.h>
 	#include <sys/socket.h>
 	#include <arpa/inet.h>
+#ifdef __FreeBSD__
+	#include <netinet/in.h>
+#endif
 	#include <netdb.h>
 	#include <signal.h>
 	#include <cerrno>


### PR DESCRIPTION
To compile on FreeBSD (12.0) I needed to add <netinet/in.h>