### PR TITLE
Marking to_string as a virtual function accessible from sock_address class

### DIFF
--- a/include/sockpp/inet6_address.h
+++ b/include/sockpp/inet6_address.h
@@ -227,7 +227,7 @@ public:
 	 * @return A string representation of the address in the form 
 	 *  	   '[address]:port'
 	 */
-	std::string to_string() const;
+	std::string to_string() const override;
 };
 
 // --------------------------------------------------------------------------

--- a/include/sockpp/inet_address.h
+++ b/include/sockpp/inet_address.h
@@ -219,7 +219,7 @@ public:
 	 * @return A string representation of the address in the form 
 	 *  	   'address:port'
 	 */
-	std::string to_string() const;
+	std::string to_string() const override;
 };
 
 // --------------------------------------------------------------------------

--- a/include/sockpp/sock_address.h
+++ b/include/sockpp/sock_address.h
@@ -94,6 +94,14 @@ public:
 		auto p = sockaddr_ptr();
 		return p ? p->sa_family : AF_UNSPEC;
 	}
+
+	/**
+	 * Gets a printable string for the address.
+	 * @return A string representation of the address
+	 */
+	virtual std::string to_string() const {
+		return std::string();
+	}
 };
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Based on my observation and my usage, sometimes it is useful to get the string representation of the IP address of the socket. But in case you have a simple `sock_address` type object, you must do some additional actions (checking the type and casting) to have your job done correctly. For this purpose, I moved the `to_string` function up to `sock_address` class and made it virtual.