### PR TITLE
[Android] Compile lib for android.

### DIFF
--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -67,7 +67,7 @@ std::string sys_error::error_str(int err)
     #else
     	#ifdef _GNU_SOURCE
 			auto s = strerror_r(err, buf, sizeof(buf));
-			return s ? std::string(s) : std::string();
+			return s ? std::to_string(s) : std::string();
         #else
             ignore_result(strerror_r(err, buf, sizeof(buf)));
         #endif


### PR DESCRIPTION
Compile lib for android.
In android the `s` in `auto s = strerror_r(err, buf, sizeof(buf));` is type `int`. 
So convert `int` to `string` is with `std::to_string()`. 
Also convert from `char*` to `string` is from `std::to_string()`.

https://stackoverflow.com/questions/32629222/how-to-use-strerror-r-properly-for-android