### PR TITLE
Add missing move constructor for connector template

### DIFF
--- a/include/sockpp/connector.h
+++ b/include/sockpp/connector.h
@@ -77,7 +77,7 @@ public:
 	/**
 	 * Creates the connector and attempts to connect to the specified
 	 * address.
-	 * @param addr The remote server address. 
+	 * @param addr The remote server address.
 	 */
 	connector(const sock_address& addr) { connect(addr); }
 	/**
@@ -145,6 +145,12 @@ public:
 	 * @param addr The remote server address.
 	 */
 	connector_tmpl(const addr_t& addr) : base(addr) {}
+	/**
+	 * Move constructor.
+	 * Creates a connector by moving the other connector to this one.
+	 * @param conn Another connector.
+	 */
+	connector_tmpl(connector_tmpl&& rhs) : base(std::move(rhs)) {}
 	/**
 	 * Move assignment.
 	 * @param rhs The other connector to move into this one.


### PR DESCRIPTION
The main template class of `tcp_connector` is missing a move constructor - it is in the base class, but not in the derived class.

This makes it impossible to use connections with `std::vector`, as it requires a move or a copy constructor.

```c++
#include <vector>

#include <sockpp/tcp_connector.h>

void foo()
{
  sockpp::tcp_connector conn;
  std::vector<sockpp::tcp_connector> connections;
  connections.push_back(std::move(conn));
}
```