### PR TITLE
Fixup: Removed trailing ';'

### DIFF
--- a/include/sockpp/tcp6_connector.h
+++ b/include/sockpp/tcp6_connector.h
@@ -60,7 +60,7 @@ using tcp6_connector = connector_tmpl<tcp6_socket>;
 
 /////////////////////////////////////////////////////////////////////////////
 // end namespace sockpp
-};
+}
 
 #endif		// __sockpp_tcp6_connector_h
 


### PR DESCRIPTION
Which triggers warning when compiling with -Wall