### PR TITLE
Fixes and Additions

### DIFF
--- a/src/acceptor.cpp
+++ b/src/acceptor.cpp
@@ -97,11 +97,15 @@ bool acceptor::open(const sock_address& addr,
 
 stream_socket acceptor::accept(sock_address* clientAddr /*=nullptr*/)
 {
-	sockaddr* p = clientAddr ? clientAddr->sockaddr_ptr() : nullptr;
-	socklen_t len = clientAddr ? clientAddr->size() : 0;
+    sockaddr_storage addrStorage;
+    sockaddr* p = clientAddr ? clientAddr->sockaddr_ptr() : nullptr;
+    socklen_t len = clientAddr ? clientAddr->size() : 0;
 
-	socket_t s = check_socket(::accept(handle(), p, clientAddr ? &len : nullptr));
-	return stream_socket(s);
+    socket_t s = check_socket(::accept(handle(), (sockaddr*)&addrStorage, &len));
+    if (clientAddr) {
+        clientAddr->set_sockaddr(addrStorage);
+    }
+    return stream_socket(s);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/linux/can_socket.cpp
+++ b/src/linux/can_socket.cpp
@@ -77,15 +77,19 @@ double can_socket::last_frame_timestamp()
 
 // --------------------------------------------------------------------------
 
-ssize_t can_socket::recv_from(can_frame *frame, int flags,
-							  can_address* srcAddr /*=nullptr*/)
+ssize_t can_socket::recv_from(can_frame *frame, int flags, can_address* srcAddr /*=nullptr*/)
 {
-	sockaddr* p = srcAddr ? srcAddr->sockaddr_ptr() : nullptr;
+    sockaddr* p = srcAddr ? srcAddr->sockaddr_ptr() : nullptr;
     socklen_t len = srcAddr ? srcAddr->size() : 0;
 
-	// TODO: Check returned length
-	return check_ret(::recvfrom(handle(), frame, sizeof(can_frame),
-								flags, p, &len));
+    // Only receive the exact size of the can_frame object
+    ssize_t ret = ::recvfrom(handle(), frame, sizeof(*frame), flags, p, &len);
+
+    if (ret == -1) {
+        throw std::system_error(errno, std::system_category(), "recvfrom failed");
+    }
+
+    return ret;
 }
 
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added a new poll()-based implementation for the connector::connect() method, replacing the select()-based implementation for systems with many sockets.

Implemented error handling for the case where bind() fails in the datagram_socket::datagram_socket() constructor, by closing the socket and returning false.

Implemented error handling for the case where recvfrom() returns a negative value in the datagram_socket::recv_from() method, by returning zero.

Fixed the return type of the datagram_socket::recv_from() method from ssize_t to int for consistency with the other methods in the class.

Fixed potential buffer overflows