### PR TITLE
Fixed building for catch2 (>=3.0)

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -39,6 +39,11 @@
 set(UNIT_TEST_DIR ${PROJECT_SOURCE_DIR})
 find_package(Catch2 REQUIRED)
 
+if (Catch2_VERSION VERSION_LESS "3.0")
+    add_definitions(-DCATCH2_V2)
+    message(WARNING "catch2 version is less than in upstream")
+endif()
+
 # --- For apps that use threads ---
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
@@ -80,6 +85,7 @@ target_include_directories(unit_tests
 		${SOCKPP_INCLUDE_DIR}
 	PRIVATE 
 		${SOCKPP_GENERATED_DIR}/include
+		${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 set_target_properties(unit_tests PROPERTIES

--- a/tests/unit/catch2_version.h
+++ b/tests/unit/catch2_version.h
@@ -1,0 +1,5 @@
+#ifdef CATCH2_V2
+    #include "catch2/catch.hpp"
+#else
+    #include "catch2/catch_all.hpp"
+#endif

--- a/tests/unit/test_acceptor.cpp
+++ b/tests/unit/test_acceptor.cpp
@@ -40,7 +40,7 @@
 
 #include "sockpp/acceptor.h"
 #include "sockpp/inet_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_can_address.cpp
+++ b/tests/unit/test_can_address.cpp
@@ -39,7 +39,7 @@
 //
 
 #include "sockpp/can_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_connector.cpp
+++ b/tests/unit/test_connector.cpp
@@ -40,7 +40,7 @@
 
 #include "sockpp/connector.h"
 #include "sockpp/sock_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_datagram_socket.cpp
+++ b/tests/unit/test_datagram_socket.cpp
@@ -40,7 +40,7 @@
 
 #include "sockpp/datagram_socket.h"
 #include "sockpp/inet_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_inet6_address.cpp
+++ b/tests/unit/test_inet6_address.cpp
@@ -39,7 +39,7 @@
 //
 
 #include "sockpp/inet6_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_inet_address.cpp
+++ b/tests/unit/test_inet_address.cpp
@@ -39,7 +39,7 @@
 //
 
 #include "sockpp/inet_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_result.cpp
+++ b/tests/unit/test_result.cpp
@@ -38,7 +38,7 @@
 //
 
 #include "sockpp/result.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 
 using namespace sockpp;
 

--- a/tests/unit/test_socket.cpp
+++ b/tests/unit/test_socket.cpp
@@ -40,7 +40,7 @@
 
 #include "sockpp/socket.h"
 #include "sockpp/inet_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_stream_socket.cpp
+++ b/tests/unit/test_stream_socket.cpp
@@ -40,7 +40,7 @@
 
 #include "sockpp/stream_socket.h"
 #include "sockpp/inet_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_tcp_socket.cpp
+++ b/tests/unit/test_tcp_socket.cpp
@@ -41,7 +41,7 @@
 #include "sockpp/tcp_socket.h"
 #include "sockpp/tcp_connector.h"
 #include "sockpp/tcp_acceptor.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_unix_address.cpp
+++ b/tests/unit/test_unix_address.cpp
@@ -39,7 +39,7 @@
 //
 
 #include "sockpp/unix_address.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_unix_dgram_socket.cpp
+++ b/tests/unit/test_unix_dgram_socket.cpp
@@ -39,7 +39,7 @@
 //
 
 #include "sockpp/unix_dgram_socket.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/test_unix_stream_socket.cpp
+++ b/tests/unit/test_unix_stream_socket.cpp
@@ -39,7 +39,7 @@
 //
 
 #include "sockpp/unix_stream_socket.h"
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 #include <string>
 
 using namespace sockpp;

--- a/tests/unit/unit_tests.cpp
+++ b/tests/unit/unit_tests.cpp
@@ -56,7 +56,7 @@
 #endif
 
 #define CATCH_CONFIG_RUNNER
-#include "catch2/catch.hpp"
+#include <catch2_version.h>
 
 int main(int argc, char* argv[]) 
 {


### PR DESCRIPTION
Fixed building for new catch2 (>=3.0). I don't like my solution for CMake but I wanted to save building for old catch2 (<3.0) for Fedora or something like that.