### PR TITLE
Fix windows test_socket fail

### DIFF
--- a/tests/unit/test_socket.cpp
+++ b/tests/unit/test_socket.cpp
@@ -126,7 +126,11 @@ TEST_CASE("socket errors", "[socket]") {
         socklen_t len = sizeof(int);
         auto res = sock.get_option(SOL_SOCKET, SO_REUSEADDR, &reuse, &len);
         REQUIRE(!res);
+#ifdef _WIN32
+        REQUIRE(errc::not_a_socket == res);
+#else
         REQUIRE(errc::bad_file_descriptor == res);
+#endif
     }
 }
 


### PR DESCRIPTION
Fixes a issue found while running unit tests on Windows.

```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
unit_tests.exe is a Catch2 v3.13.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
socket errors
  basic errors
-------------------------------------------------------------------------------
tests/unit/test_socket.cpp(120)
...............................................................................

tests/unit/test_socket.cpp(129): FAILED:
  REQUIRE( errc::bad_file_descriptor == res )
with expansion:
  9 == {?}

===============================================================================
test cases:  41 |  40 passed | 1 failed
assertions: 241 | 240 passed | 1 failed
```
